### PR TITLE
fix: Add BOT_ACCESS-TOKEN to task checker workflow

### DIFF
--- a/.github/workflows/pr-task-check.yml
+++ b/.github/workflows/pr-task-check.yml
@@ -7,6 +7,9 @@ on:
       - reopened
       - edited
 
+env:
+  GITHUB_TOKEN: ${{ secrets.BOT_ACCESS_TOKEN }}
+
 jobs:
   task-check:
     name: Task Check
@@ -14,4 +17,4 @@ jobs:
     steps:
       - uses: kentaro-m/task-completed-checker-action@v0.1.0
         with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          repo-token: '${{ env.GITHUB_TOKEN }}'


### PR DESCRIPTION
## Related Issue

Closes #10 

## Overall description of your work

Added BOT_ACCESS-TOKEN to task checker workflow so it can use the bot admin rights to execute.

## Technical decisions you've made

*Nothing*

## Task list

- [x] Fix task checker workflow
